### PR TITLE
fix: intercom event meta-data doc link

### DIFF
--- a/docs/destinations/streaming-destinations/intercom.mdx
+++ b/docs/destinations/streaming-destinations/intercom.mdx
@@ -320,7 +320,7 @@ rudderanalytics.track("Order Completed", {
 
 <div class="infoBlock">
 
-RudderStack converts and sends all the <code class="inline-code">track</code> event properties as per the <a href="https://developers.intercom.com/intercom-api-reference/reference#event-metadata-types">Intercom API</a>.
+RudderStack converts and sends all the <code class="inline-code">track</code> event properties as per the <a href="https://developers.intercom.com/docs/references/1.4/rest-api/data-events/event-metadata-types/">Intercom API</a>.
 </div>
 
 ## Page


### PR DESCRIPTION
## What do these changes do?

Fix incorrect doc link for intercom api

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
